### PR TITLE
Fix backend traffic policy duplication, add Lua/WASM policy handling, and improve KM cache logic with tenant support

### DIFF
--- a/apk/gateway-connector/internal/k8sClient/k8s_client.go
+++ b/apk/gateway-connector/internal/k8sClient/k8s_client.go
@@ -48,6 +48,11 @@ import (
 
 // !!! ======== NEW ========
 
+const (
+	// Shared BackendTrafficPolicy name for all subscription rate limit policies
+	SharedRateLimitPolicyName = "kgw-shared-subscription-rl-policy"
+)
+
 // UndeployRouteMetadataCRs removes all RouteMetadata Custom Resource from the Kubernetes cluster based on API ID label.
 func UndeployRouteMetadataCRs(apiID string, k8sClient client.Client) {
 	conf, errReadConfig := config.ReadConfigs()
@@ -532,7 +537,7 @@ func UpdateRateLimitPolicyCR(policy eventhubTypes.RateLimitPolicy, k8sClient cli
 func DeploySubscriptionRateLimitPolicyCR(policy eventhubTypes.SubscriptionPolicy, k8sClient client.Client) {
 	conf, _ := config.ReadConfigs()
 	crRLBackendTrafficPolicy := gatewayv1alpha1.BackendTrafficPolicy{}
-	crName := PrepareSubscritionPolicyCRName(policy.Name, policy.TenantDomain)
+	crName := utils.CreateSubscriptionPolicyName(policy.Name, policy.TenantDomain)
 
 	unit, requestsPerUnit := getRateLimitPolicyContents(policy)
 	loggers.LoggerK8sClient.Infof("Requests Per Unit after parsing: %d | Unit: %s", requestsPerUnit, unit)
@@ -543,8 +548,8 @@ func DeploySubscriptionRateLimitPolicyCR(policy eventhubTypes.SubscriptionPolicy
 		gatewayName = "wso2-kgw-default"
 	}
 	labelMap := map[string]string{
-		"InitiateFrom": "CP",
-		"CPName":       policy.Name,
+		"kgw.wso2.com/cpInitiated": "true",
+		"kgw.wso2.com/cpName":      policy.Name,
 	}
 
 	if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: conf.DataPlane.Namespace, Name: crName}, &crRLBackendTrafficPolicy); err != nil {
@@ -638,8 +643,8 @@ func DeployAIRateLimitPolicyFromCPPolicy(policy eventhubTypes.SubscriptionPolicy
 	}
 
 	labelMap := map[string]string{
-		"InitiateFrom": "CP",
-		"CPName":       policy.Name,
+		"kgw.wso2.com/cpInitiated": "true",
+		"kgw.wso2.com/cpName":      policy.Name,
 	}
 
 	crRLBackendTrafficPolicy := gatewayv1alpha1.BackendTrafficPolicy{
@@ -921,12 +926,14 @@ func UpdateSecurityPolicyCRs(keymanagerName string, tenantDomain string, k8sClie
 		loggers.LoggerK8sClient.Error("Unable to list SecurityPolicy CR: " + err.Error())
 	}
 	if len(securityPolicyList.Items) == 0 {
-		loggers.LoggerK8sClient.Infof("No SecurityPolicy CR found for deletion")
+		loggers.LoggerK8sClient.Infof("No SecurityPolicy CR found for update")
 	}
 	for _, securitypolicy := range securityPolicyList.Items {
 		providers := securitypolicy.Spec.JWT.Providers
+		loggers.LoggerK8sClient.Infof("Providers: %+v", providers)
 		updated := false    // Track if any changes were made
 		if removeProvider { // Remove the provider details from JWT segment in each CR
+			loggers.LoggerK8sClient.Infof("Removing the provider from the SecurityPolicy")
 			updatedProviders := []gatewayv1alpha1.JWTProvider{}
 			for _, provider := range providers {
 				if provider.Name != keymanagerName {
@@ -1223,7 +1230,7 @@ func RetrieveAllRatelimitPoliciesSFromK8s(ratelimitName string, organization str
 	conf, _ := config.ReadConfigs()
 	rlBackendTPList := gatewayv1alpha1.BackendTrafficPolicyList{}
 	resolvedRLBackendTPList := make([]gatewayv1alpha1.BackendTrafficPolicy, 0)
-	labelMap := map[string]string{"rateLimitPolicyName": ratelimitName, "organization": organization}
+	labelMap := map[string]string{"kgw.wso2.com/policyName": ratelimitName, "kgw.wso2.com/organization": organization, "kgw.wso2.com/cpInitiated": "true"}
 	// !!! Might need to change this later
 	// Create a list option with the label selector
 	listOption := &client.ListOptions{
@@ -1247,7 +1254,7 @@ func RetrieveAllAIRatelimitPoliciesSFromK8s(aiRatelimitName string, organization
 	conf, _ := config.ReadConfigs()
 	airlBackendTPList := gatewayv1alpha1.BackendTrafficPolicyList{}
 	resolvedAIRLBackendTPList := make([]gatewayv1alpha1.BackendTrafficPolicy, 0)
-	labelMap := map[string]string{"rateLimitPolicyName": aiRatelimitName, "organization": organization}
+	labelMap := map[string]string{"kgw.wso2.com/policyName": aiRatelimitName, "kgw.wso2.com/organization": organization, "kgw.wso2.com/cpInitiated": "true"}
 	// !!! Might need to change this later
 	// Create a list option with the label selector
 	listOption := &client.ListOptions{
@@ -1350,7 +1357,7 @@ func GenerateKMBackendCR(km eventhubTypes.ResolvedKeyManager, backendPort int, b
 			Labels: map[string]string{
 				"kgw.wso2.com/name":         km.Name,
 				"kgw.wso2.com/organization": km.Organization,
-				"kgw.wso2.com/cpInitiated": "true",
+				"kgw.wso2.com/cpInitiated":  "true",
 			},
 		},
 		Spec: gatewayv1alpha1.BackendSpec{
@@ -1422,7 +1429,7 @@ func GenerateKMBackendTLSCR(km eventhubTypes.ResolvedKeyManager, backendName, na
 			Labels: map[string]string{
 				"kgw.wso2.com/name":         km.Name,
 				"kgw.wso2.com/organization": km.Organization,
-				"kgw.wso2.com/cpInitiated": "true",
+				"kgw.wso2.com/cpInitiated":  "true",
 			},
 		},
 		Spec: gwapiv1a3.BackendTLSPolicySpec{
@@ -1460,4 +1467,291 @@ func DeleteBackendCRByName(backendName, namespace string, k8sClient client.Clien
 	}
 	loggers.LoggerK8sClient.Infof("Successfully deleted Backend CR '%s'", backendName)
 	return nil
+}
+
+
+// RetrieveSharedSubscriptionRateLimitPolicyFromK8s retrieves the shared BackendTrafficPolicy for the given organization
+// and extracts all policy names from the rules headers
+func RetrieveSharedSubscriptionRateLimitPolicyFromK8s(organization string, k8sClient client.Client) ([]string, error) {
+	conf, _ := config.ReadConfigs()
+	sharedPolicyName := utils.CreateSubscriptionPolicyName(SharedRateLimitPolicyName, organization)
+	
+	// Get the shared BackendTrafficPolicy
+	existingPolicy := &gatewayv1alpha1.BackendTrafficPolicy{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{
+		Namespace: conf.DataPlane.Namespace,
+		Name:      sharedPolicyName,
+	}, existingPolicy)
+
+	if err != nil {
+		if k8error.IsNotFound(err) {
+			loggers.LoggerK8sClient.Infof("Shared RateLimit BackendTrafficPolicy not found for organization: %s", organization)
+			return []string{}, nil // Return empty slice, not an error
+		}
+		loggers.LoggerK8sClient.Errorf("Unable to get shared RateLimit BackendTrafficPolicy CR: %v", err)
+		return nil, err
+	}
+
+	// Extract policy names from the rules headers
+	policyNames := []string{}
+	for _, rule := range existingPolicy.Spec.RateLimit.Global.Rules {
+		for _, selector := range rule.ClientSelectors {
+			for _, header := range selector.Headers {
+				if header.Name == "policy-id" && header.Value != nil && *header.Value != "" {
+					policyNames = append(policyNames, *header.Value)
+					break // Found policy-id for this rule, break inner loops
+				}
+			}
+		}
+	}
+
+	loggers.LoggerK8sClient.Debugf("Retrieved %d policy names from shared BackendTrafficPolicy for organization %s: %v", 
+		len(policyNames), organization, policyNames)
+	return policyNames, nil
+}
+
+// DeploySubscriptionRateLimitPolicyCR applies the given RateLimitPolicies struct to the Kubernetes cluster.
+func DeploySharedSubscriptionRateLimitPolicyCR(policy eventhubTypes.SubscriptionPolicy, k8sClient client.Client, aiPolicy bool) {
+	conf, _ := config.ReadConfigs()
+
+	unit, requestsPerUnit := getRateLimitPolicyContents(policy)
+	loggers.LoggerK8sClient.Infof("Requests Per Unit after parsing: %d | Unit: %s", requestsPerUnit, unit)
+
+	gatewayName, _ := getGatewayNameFromK8s(k8sClient)
+	loggers.LoggerK8sClient.Infof("Gateway Name fetched from the k8s cluster: %s", gatewayName)
+	if gatewayName == "" {
+		gatewayName = "wso2-kgw-default"
+	}
+	sharedPolicyName := utils.CreateSubscriptionPolicyName(SharedRateLimitPolicyName, policy.TenantDomain)
+	// Create the new rule for this policy
+	var newRule gatewayv1alpha1.RateLimitRule
+	if !aiPolicy {
+		newRule = gatewayv1alpha1.RateLimitRule{
+			ClientSelectors: []gatewayv1alpha1.RateLimitSelectCondition{
+				{
+					Headers: []gatewayv1alpha1.HeaderMatch{
+						{
+							Name:   "x-wso2-api-id",
+							Value:  ptr.To(""),
+							Invert: ptr.To(false),
+						},
+						{
+							Name:   "x-wso2-organization",
+							Value:  ptr.To(""),
+							Invert: ptr.To(false),
+						},
+						{
+							Name:   "x-wso2-subscription-id",
+							Value:  ptr.To(""),
+							Invert: ptr.To(false),
+						},
+						{
+							Name:   "policy-id",
+							Value:  &policy.Name,
+							Invert: ptr.To(false),
+						},
+					},
+				},
+			},
+			Limit: gatewayv1alpha1.RateLimitValue{
+				Requests: requestsPerUnit,
+				Unit:     unit,
+			},
+			Shared: ptr.To(false),
+		}
+	} else {
+		// Create the new rule for this AI policy
+		newRule = gatewayv1alpha1.RateLimitRule{
+			ClientSelectors: []gatewayv1alpha1.RateLimitSelectCondition{
+				{
+					Headers: []gatewayv1alpha1.HeaderMatch{
+						{
+							Name:   "x-wso2-api-id",
+							Value:  ptr.To(""),
+							Invert: ptr.To(false),
+						},
+						{
+							Name:   "x-wso2-organization",
+							Value:  ptr.To(""),
+							Invert: ptr.To(false),
+						},
+						{
+							Name:   "x-wso2-subscription-id",
+							Value:  ptr.To(""),
+							Invert: ptr.To(false),
+						},
+						{
+							Name:   "cost",
+							Value:  ptr.To(""),
+							Invert: ptr.To(false),
+						},
+						{
+							Name:   "policy-id",
+							Value:  &policy.Name,
+							Invert: ptr.To(false),
+						},
+					},
+				},
+			},
+			Limit: gatewayv1alpha1.RateLimitValue{
+				Requests: requestsPerUnit,
+				Unit:     unit,
+			},
+			Shared: ptr.To(false),
+		}
+	}
+
+	// Try to get existing shared BackendTrafficPolicy
+	existingPolicy := &gatewayv1alpha1.BackendTrafficPolicy{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{
+		Namespace: conf.DataPlane.Namespace,
+		Name:      sharedPolicyName,
+	}, existingPolicy)
+
+	if err != nil {
+		if k8error.IsNotFound(err) {
+			// Create new shared BackendTrafficPolicy
+			sharedPolicy := &gatewayv1alpha1.BackendTrafficPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sharedPolicyName,
+					Namespace: conf.DataPlane.Namespace,
+					Labels: map[string]string{
+						"kgw.wso2.com/cpInitiated":  "true",
+						"kgw.wso2.com/type":         "subscription-ratelimit",
+						"kgw.wso2.com/organization": policy.TenantDomain,
+					},
+				},
+				Spec: gatewayv1alpha1.BackendTrafficPolicySpec{
+					MergeType: ptr.To(gatewayv1alpha1.MergeType("StrategicMerge")),
+					RateLimit: &gatewayv1alpha1.RateLimitSpec{
+						Type: gatewayv1alpha1.RateLimitType("Global"),
+						Global: &gatewayv1alpha1.GlobalRateLimit{
+							Rules: []gatewayv1alpha1.RateLimitRule{newRule},
+						},
+					},
+					PolicyTargetReferences: gatewayv1alpha1.PolicyTargetReferences{
+						TargetRefs: []gwapiv1a2.LocalPolicyTargetReferenceWithSectionName{
+							{
+								LocalPolicyTargetReference: gwapiv1a2.LocalPolicyTargetReference{
+									Group: gwapiv1a2.Group(constants.GatewayGroup),
+									Kind:  gwapiv1a2.Kind("Gateway"),
+									Name:  gwapiv1a2.ObjectName(gatewayName),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			if err := k8sClient.Create(context.Background(), sharedPolicy); err != nil {
+				loggers.LoggerK8sClient.Errorf("Unable to create the initial shared subscription rateLimit BackendTrafficPolicy CR: %+v", err)
+			} else {
+				loggers.LoggerK8sClient.Infof("Shared Subscription RateLimit BackendTrafficPolicy CR created: %s", sharedPolicy.Name)
+			}
+		} else {
+			loggers.LoggerK8sClient.Errorf("Unable to get shared Subscription RateLimit BackendTrafficPolicy CR: %+v", err)
+		}
+	} else {
+		// Update existing shared BackendTrafficPolicy by adding/updating the rule
+		ruleUpdated := false
+
+		// Check if a rule for this policy already exists
+		for i, rule := range existingPolicy.Spec.RateLimit.Global.Rules {
+			// Check if this rule belongs to the current policy by examining headers
+			for _, selector := range rule.ClientSelectors {
+				for _, header := range selector.Headers {
+					if header.Name == "policy-id" && header.Value != nil && *header.Value == policy.Name {
+						// Update existing rule
+						existingPolicy.Spec.RateLimit.Global.Rules[i] = newRule
+						ruleUpdated = true
+						break
+					}
+				}
+				if ruleUpdated {
+					break
+				}
+			}
+			if ruleUpdated {
+				break
+			}
+		}
+
+		// If no existing rule found, add new rule
+		if !ruleUpdated {
+			existingPolicy.Spec.RateLimit.Global.Rules = append(existingPolicy.Spec.RateLimit.Global.Rules, newRule)
+		}
+
+		if err := k8sClient.Update(context.Background(), existingPolicy); err != nil {
+			loggers.LoggerK8sClient.Errorf("Unable to update shared RateLimit BackendTrafficPolicy CR: %+v", err)
+		} else {
+			loggers.LoggerK8sClient.Infof("Shared RateLimit BackendTrafficPolicy CR updated with policy: %s", policy.Name)
+		}
+	}
+}
+
+// UnDeploySubscriptionRateLimitPolicyCR removes the rate limit rule for the given policy from the shared BackendTrafficPolicy.
+func UnDeploySharedSubscriptionRateLimitPolicyCR(policyName string, tenantDomain string, k8sClient client.Client, aiPolicy bool) {
+	conf, _ := config.ReadConfigs()
+	sharedPolicyName := utils.CreateSubscriptionPolicyName(SharedRateLimitPolicyName, tenantDomain)
+	// Get the shared BackendTrafficPolicy
+	existingPolicy := &gatewayv1alpha1.BackendTrafficPolicy{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{
+		Namespace: conf.DataPlane.Namespace,
+		Name:      sharedPolicyName,
+	}, existingPolicy)
+
+	if err != nil {
+		if k8error.IsNotFound(err) {
+			loggers.LoggerK8sClient.Infof("Shared RateLimit BackendTrafficPolicy not found, nothing to remove for policy: %s", policyName)
+		} else {
+			loggers.LoggerK8sClient.Errorf("Unable to get shared RateLimit BackendTrafficPolicy CR: %v", err)
+		}
+		return
+	}
+
+	// Remove the rule for this policy
+	updatedRules := []gatewayv1alpha1.RateLimitRule{}
+	ruleFound := false
+
+	for _, rule := range existingPolicy.Spec.RateLimit.Global.Rules {
+		shouldKeepRule := true
+		for _, selector := range rule.ClientSelectors {
+			for _, header := range selector.Headers {
+				if header.Name == "policy-id" && header.Value != nil && *header.Value == policyName {
+					shouldKeepRule = false
+					ruleFound = true
+					break
+				}
+			}
+			if !shouldKeepRule {
+				break
+			}
+		}
+		if shouldKeepRule {
+			updatedRules = append(updatedRules, rule)
+		}
+	}
+
+	if !ruleFound {
+		loggers.LoggerK8sClient.Infof("Rule for policy '%s' not found in shared BackendTrafficPolicy", policyName)
+		return
+	}
+
+	// Update or delete the policy based on remaining rules
+	if len(updatedRules) == 0 {
+		// No rules left, delete the entire BackendTrafficPolicy
+		if err := k8sClient.Delete(context.Background(), existingPolicy); err != nil {
+			loggers.LoggerK8sClient.Errorf("Unable to delete shared RateLimit BackendTrafficPolicy CR: %v", err)
+		} else {
+			loggers.LoggerK8sClient.Infof("Shared RateLimit BackendTrafficPolicy CR deleted as no rules remain")
+		}
+	} else {
+		// Update with remaining rules
+		existingPolicy.Spec.RateLimit.Global.Rules = updatedRules
+		if err := k8sClient.Update(context.Background(), existingPolicy); err != nil {
+			loggers.LoggerK8sClient.Errorf("Unable to update shared RateLimit BackendTrafficPolicy CR after removing rule: %v", err)
+		} else {
+			loggers.LoggerK8sClient.Infof("Rule for policy '%s' removed from shared BackendTrafficPolicy", policyName)
+		}
+	}
 }

--- a/apk/gateway-connector/internal/synchronizer/ratelimit_policy_fetcher.go
+++ b/apk/gateway-connector/internal/synchronizer/ratelimit_policy_fetcher.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// !!! NOTE: This handles the normal ratelimit policies
 // FetchRateLimitPoliciesOnEvent fetches the policies from the control plane on the start up and notification event updates
 func FetchRateLimitPoliciesOnEvent(ratelimitName string, organization string, c client.Client) {
 	// Read configurations and derive the eventHub details
@@ -58,7 +59,6 @@ func FetchRateLimitPoliciesOnEvent(ratelimitName string, organization string, c 
 				} else if policy.DefaultLimit.RequestCount.TimeUnit == "day" {
 					policy.DefaultLimit.RequestCount.TimeUnit = "Day"
 				}
-				// !!!TODO: NEED TO ADD THE LOGIC
 				// Update the exisitng rate limit policies with current policy
 				k8sclient.UpdateRateLimitPolicyCR(policy, c)
 				logger.LoggerSynchronizer.Debugf("RateLimit Policy updated: %v", policy)
@@ -86,54 +86,74 @@ func FetchSubscriptionRateLimitPoliciesOnEvent(ratelimitName string, organizatio
 				logger.LoggerSynchronizer.Infof("Cleaning up deleted AI ratelimit policies")
 				// !!!TODO: NEED TO ADD THE LOGIC
 				// This logic is executed once at the startup time so no need to worry about the nested for loops for performance.
-				// Fetch all AiRatelimitPolicies
-				airls, retrieveAllAIRLErr := k8sclient.RetrieveAllAIRatelimitPoliciesSFromK8s(ratelimitName, organization, c)
-				if retrieveAllAIRLErr == nil {
-					for _, airl := range airls {
-						if cpName, exists := airl.ObjectMeta.Labels["CPName"]; exists {
-							found := false
-							for _, policy := range rateLimitPolicies {
-								if policy.Name == cpName {
-									found = true
-									break
-								}
+				deployedPolicyNames, retrieveErr := k8sclient.RetrieveSharedSubscriptionRateLimitPolicyFromK8s(organization, c)
+				if retrieveErr == nil {
+					for _, deployedPolicyName := range deployedPolicyNames {
+						found := false
+						for _, policy := range rateLimitPolicies {
+							if policy.Name == deployedPolicyName {
+								found = true
+								break
 							}
-							if !found {
-								// Delete the airatelimitpolicy
-								k8sclient.UndeploySubscriptionAIRateLimitPolicyCR(airl.Name, c)
-							}
+						}
+						if !found {
+							// Delete the rate limit policy rule
+							logger.LoggerSynchronizer.Infof("Removing outdated rate limit policy: %s", deployedPolicyName)
+							k8sclient.UnDeploySharedSubscriptionRateLimitPolicyCR(deployedPolicyName, organization, c, false)
 						}
 					}
 				} else {
-					logger.LoggerSynchronizer.Errorf("Error while fetching airatelimitpolicies for cleaning up outdataed crs. Error: %+v", retrieveAllAIRLErr)
+					logger.LoggerSynchronizer.Errorf("Error while fetching deployed rate limit policies for cleanup. Error: %+v", retrieveErr)
 				}
+				// // Fetch all AI RatelimitPolicies
+				// airls, retrieveAllAIRLErr := k8sclient.RetrieveAllAIRatelimitPoliciesSFromK8s(ratelimitName, organization, c)
+				// if retrieveAllAIRLErr == nil {
+				// 	for _, airl := range airls {
+				// 		if cpName, exists := airl.ObjectMeta.Labels["CPName"]; exists {
+				// 			found := false
+				// 			for _, policy := range rateLimitPolicies {
+				// 				if policy.Name == cpName {
+				// 					found = true
+				// 					break
+				// 				}
+				// 			}
+				// 			if !found {
+				// 				// Delete the airatelimitpolicy
+				// 				k8sclient.UnDeploySharedSubscriptionRateLimitPolicyCR(airl.Name, organization, c, true)
+				// 			}
+				// 		}
+				// 	}
+				// } else {
+				// 	logger.LoggerSynchronizer.Errorf("Error while fetching airatelimitpolicies for cleaning up outdataed crs. Error: %+v", retrieveAllAIRLErr)
+				// }
 
-				rls, retrieveAllRLErr := k8sclient.RetrieveAllRatelimitPoliciesSFromK8s(ratelimitName, organization, c)
-				if retrieveAllRLErr == nil {
-					for _, rl := range rls {
-						if cpName, exists := rl.ObjectMeta.Labels["CPName"]; exists {
-							found := false
-							for _, policy := range rateLimitPolicies {
-								if policy.Name == cpName {
-									found = true
-									break
-								}
-							}
-							if !found {
-								// Delete the airatelimitpolicy
-								k8sclient.UnDeploySubscriptionRateLimitPolicyCR(rl.Name, c)
-							}
-						}
-					}
-				} else {
-					logger.LoggerSynchronizer.Errorf("Error while fetching ratelimitpolicies for cleaning up outdataed crs. Error: %+v", retrieveAllRLErr)
-				}
+				// // Fetch all Normal RatelimitPolicies
+				// rls, retrieveAllRLErr := k8sclient.RetrieveAllRatelimitPoliciesSFromK8s(ratelimitName, organization, c)
+				// if retrieveAllRLErr == nil {
+				// 	for _, rl := range rls {
+				// 		if cpName, exists := rl.ObjectMeta.Labels["CPName"]; exists {
+				// 			found := false
+				// 			for _, policy := range rateLimitPolicies {
+				// 				if policy.Name == cpName {
+				// 					found = true
+				// 					break
+				// 				}
+				// 			}
+				// 			if !found {
+				// 				// Delete the airatelimitpolicy
+				// 				k8sclient.UnDeploySharedSubscriptionRateLimitPolicyCR(rl.Name, organization, c, false)
+				// 			}
+				// 		}
+				// 	}
+				// } else {
+				// 	logger.LoggerSynchronizer.Errorf("Error while fetching ratelimitpolicies for cleaning up outdataed crs. Error: %+v", retrieveAllRLErr)
+				// }
 			}
 
 			for _, policy := range rateLimitPolicies {
 				if policy.QuotaType == "aiApiQuota" {
-					logger.LoggerSynchronizer.Debugf("AI Subscription RateLimit Policy detected...")
-					logger.LoggerSynchronizer.Debugf("AIAPIQuota data: %+v", policy.DefaultLimit.AiAPIQuota)
+					logger.LoggerSynchronizer.Infof("AI Subscription RateLimit Policy detected...")
+					logger.LoggerSynchronizer.Infof("AIAPIQuota data: %+v", policy.DefaultLimit.AiAPIQuota)
 					if policy.DefaultLimit.AiAPIQuota != nil {
 						// switch policy.DefaultLimit.AiAPIQuota.TimeUnit {
 						// case "min":
@@ -148,7 +168,7 @@ func FetchSubscriptionRateLimitPoliciesOnEvent(ratelimitName string, organizatio
 						// 	logger.LoggerSynchronizer.Errorf("Unsupported timeunit %s", policy.DefaultLimit.AiAPIQuota.TimeUnit)
 						// 	continue
 						// }
-						// !!! Need to check what this logic is 
+						// !!! Need to check what this logic is
 						if policy.DefaultLimit.AiAPIQuota.PromptTokenCount == nil && policy.DefaultLimit.AiAPIQuota.TotalTokenCount != nil {
 							policy.DefaultLimit.AiAPIQuota.PromptTokenCount = policy.DefaultLimit.AiAPIQuota.TotalTokenCount
 						}
@@ -159,21 +179,20 @@ func FetchSubscriptionRateLimitPoliciesOnEvent(ratelimitName string, organizatio
 							total := *policy.DefaultLimit.AiAPIQuota.PromptTokenCount + *policy.DefaultLimit.AiAPIQuota.CompletionTokenCount
 							policy.DefaultLimit.AiAPIQuota.TotalTokenCount = &total
 						}
-						logger.LoggerSynchronizer.Debugf("\n\nAI Subscription RateLimit Policy added from CP: %+v", policy)
-						// !!!TODO: NEED TO ADD THE LOGIC
-						logger.LoggerSynchronizer.Debugf("Policy Quota Type: %s", policy.QuotaType)
-						logger.LoggerSynchronizer.Debugf("AI -> PromptTokenCount: %d", *policy.DefaultLimit.AiAPIQuota.PromptTokenCount)
-						logger.LoggerSynchronizer.Debugf("AI -> CompletionTokenCount: %d", *policy.DefaultLimit.AiAPIQuota.CompletionTokenCount)
-						logger.LoggerSynchronizer.Debugf("AI -> TotalTokenCount: %d", *policy.DefaultLimit.AiAPIQuota.TotalTokenCount)
+						logger.LoggerSynchronizer.Infof("\n\nAI Subscription RateLimit Policy added from CP: %+v", policy)
+						logger.LoggerSynchronizer.Infof("Policy Quota Type: %s", policy.QuotaType)
+						logger.LoggerSynchronizer.Infof("AI -> PromptTokenCount: %d", *policy.DefaultLimit.AiAPIQuota.PromptTokenCount)
+						logger.LoggerSynchronizer.Infof("AI -> CompletionTokenCount: %d", *policy.DefaultLimit.AiAPIQuota.CompletionTokenCount)
+						logger.LoggerSynchronizer.Infof("AI -> TotalTokenCount: %d", *policy.DefaultLimit.AiAPIQuota.TotalTokenCount)
 						managementserver.AddSubscriptionPolicy(policy)
-						logger.LoggerSynchronizer.Debugf("AI Subscription RateLimit Policy added to internal map")
-						// k8sclient.DeployAIRateLimitPolicyFromCPPolicy(policy, c)
-						logger.LoggerSynchronizer.Debugf("AI RateLimit Policy added from CP Policy: %v", policy)
+						logger.LoggerSynchronizer.Infof("AI Subscription RateLimit Policy added to internal map")
+						k8sclient.DeploySharedSubscriptionRateLimitPolicyCR(policy, c, true)
+						logger.LoggerSynchronizer.Infof("AI RateLimit Policy added from CP Policy: %+v \n\n", policy)
 					} else {
 						logger.LoggerSynchronizer.Errorf("AIQuota type response recieved but no data found. %+v", policy.DefaultLimit)
 					}
 				} else {
-					logger.LoggerSynchronizer.Debugf("\n\nNormal Subscription RateLimit policy added from CP: %+v", policy)
+					logger.LoggerSynchronizer.Infof("\n\nNormal Subscription RateLimit policy added from CP: %+v", policy)
 					if policy.DefaultLimit.RequestCount.TimeUnit == "min" {
 						policy.DefaultLimit.RequestCount.TimeUnit = "Minute"
 					} else if policy.DefaultLimit.RequestCount.TimeUnit == "hours" {
@@ -186,9 +205,8 @@ func FetchSubscriptionRateLimitPoliciesOnEvent(ratelimitName string, organizatio
 					managementserver.AddSubscriptionPolicy(policy)
 					logger.LoggerSynchronizer.Debug("Normal Subscription RateLimit Policy added to internal map")
 					// Update the exisitng rate limit policies with current policy
-					// !!!TODO: NEED TO ADD THE LOGIC
-					// k8sclient.DeploySubscriptionRateLimitPolicyCR(policy, c)
-					logger.LoggerSynchronizer.Debugf("Subscription RL Policy added: %v", policy)
+					k8sclient.DeploySharedSubscriptionRateLimitPolicyCR(policy, c, false)
+					logger.LoggerSynchronizer.Infof("Subscription RL Policy added: %+v \n\n", policy)
 				}
 			}
 		}

--- a/apk/gateway-connector/internal/utils/helpers.go
+++ b/apk/gateway-connector/internal/utils/helpers.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	logger "github.com/wso2-extensions/apim-gw-connectors/apk/gateway-connector/internal/loggers"
 	"github.com/wso2-extensions/apim-gw-connectors/common-agent/config"
@@ -53,8 +54,22 @@ func ExtractHostnameAndPort(serverURL string) (string, int, error) {
 	host, port := u.Hostname(), u.Port()
 	portInt, err := strconv.Atoi(port)
 	if err != nil {
-		return "", -1, err
+		// No explicit port provided, use default based on scheme
+		switch u.Scheme {
+			case "https":
+				portInt = 443
+			case "http":
+				portInt = 80
+			default:
+				// For unknown schemes, try to infer from URL or use a reasonable default
+				if strings.Contains(strings.ToLower(serverURL), "https") {
+					portInt = 443
+				} else {
+					portInt = 80
+				}
+		}
 	}
+	logger.LoggerUtils.Infof("Host: %s, Port: %d", host, portInt)
 	return host, portInt, nil
 }
 

--- a/apk/gateway-connector/internal/utils/helpers.go
+++ b/apk/gateway-connector/internal/utils/helpers.go
@@ -105,3 +105,8 @@ func CreateAIProviderName(providerName string, ProviderAPIVersion string) string
 	// This ensures that the name is unique and does not exceed length limits
 	return "ai-provider-" + HashLast50SHA1(providerName+ProviderAPIVersion)
 }
+
+// CreateSubscriptionPolicyName creates a unique name for the subscription policy based on the policy name and organization.
+func CreateSubscriptionPolicyName(policyName string, organization string) string {
+	return "subscription-" + HashLast50SHA1(policyName+organization)
+}

--- a/common-agent/config/default_config.go
+++ b/common-agent/config/default_config.go
@@ -46,6 +46,9 @@ var defaultConfig = &Config{
 		},
 		InternalKeyIssuer: "http://am.wso2.com:443/token",
 		Provider:          "admin",
+		Certificates: certificates{
+			CaCertSecretName: "$env{CA_CERT_SECRET_NAME}",
+		},
 	},
 	Agent: agent{
 		Enabled: true,

--- a/common-agent/config/types.go
+++ b/common-agent/config/types.go
@@ -122,6 +122,7 @@ type controlPlane struct {
 	ClientID                   string
 	ClientSecret               string
 	Provider                   string
+	Certificates               certificates
 }
 
 // Dataplane struct contains the configurations related to the APK
@@ -156,4 +157,9 @@ type metrics struct {
 	Enabled bool
 	Type    string
 	Port    int32
+}
+
+// Certificates struct contains the configurations related to the certificates
+type certificates struct {
+	CaCertSecretName string
 }

--- a/common-agent/helm/templates/deployment.yaml
+++ b/common-agent/helm/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
               value: {{ .Values.service.name }}.{{ .Release.Namespace }}.svc
             - name: APIM_AGENT_GRPC_PORT
               value: "18000"
+            - name: CA_CERT_SECRET_NAME
+              value: "{{ .Values.controlPlane.certificates.caCertSecretName | default "apim-ca-certificate" }}"
           volumeMounts:
             - name: log-conf-volume
               mountPath: /home/wso2/conf/

--- a/common-agent/internal/constants/constants.go
+++ b/common-agent/internal/constants/constants.go
@@ -27,6 +27,8 @@ const (
 	RedirectRequest         = "apkRedirectRequest"
 	ModelWeightedRoundRobin = "modelWeightedRoundRobin"
 	ModelRoundRobin         = "modelRoundRobin"
+	LuaInterceptorService  = "apkLuaInterceptorService"
+	WASMInterceptorService = "apkWASMInterceptorService"
 
 	// Version constants
 	V1 = "v1"

--- a/common-agent/pkg/transformer/api_model.go
+++ b/common-agent/pkg/transformer/api_model.go
@@ -125,6 +125,30 @@ type InterceptorService struct {
 
 func (s InterceptorService) isParameter() {}
 
+// LuaInterceptor represents the configuration for Lua interceptor policies.
+type LuaInterceptor struct {
+	Name              string `yaml:"name,omitempty"`
+	SourceCode        string `yaml:"sourceCode,omitempty"`
+	SourceCodeRef     string `yaml:"sourceCodeRef,omitempty"`
+	MountInConfigMap  bool   `yaml:"mountInConfigMap,omitempty"`
+}
+
+func (l LuaInterceptor) isParameter() {}
+
+// WASMInterceptor represents the configuration for WASM interceptor policies.
+type WASMInterceptor struct {
+	Name             string   `yaml:"name,omitempty"`
+	RootID           string   `yaml:"rootId,omitempty"`
+	URL              string   `yaml:"url,omitempty"`
+	Image            string   `yaml:"image,omitempty"`
+	ImagePullPolicy  string   `yaml:"imagePullPolicy,omitempty"`
+	Config           string   `yaml:"config,omitempty"`
+	FailOpen         bool     `yaml:"failOpen,omitempty"`
+	HostKeys         []string `yaml:"hostKeys,omitempty"`
+}
+
+func (w WASMInterceptor) isParameter() {}
+
 // BackendJWT holds configuration details for configuring JWT for backend
 type BackendJWT struct {
 	Encoding         string `yaml:"encoding,omitempty"`

--- a/common-agent/pkg/transformer/constants.go
+++ b/common-agent/pkg/transformer/constants.go
@@ -93,6 +93,8 @@ const (
 	requestRedirectPolicy = "RequestRedirect"
 	requestMirrorPolicy   = "RequestMirror"
 	modelBasedRoundRobin  = "ModelBasedRoundRobin"
+	luaInterceptorPolicy  = "LuaInterceptor"
+	wasmInterceptorPolicy = "WASMInterceptor"
 
 	// APK BackendJWT parameter constants
 	base64url = "Base64url"


### PR DESCRIPTION
## Purpose
- This PR adds multiple bug fixes and improvements to the following flows
> - Modifying logic to create one BackendTrafficPolicy for all Subscription Rate Limit Policies because with the previous logic it will create one BackendTrafficPolicy for each policy in the gateway level but in the Envoy gateway we can only have one such gateway level BackendTrafficPolicy 
> - Adding the logic for decoding and adding Lua and WASM Policies(for KGW APIs) into the APK-Conf
> - Changing KM cache and its related resource handling logic to incorporate tenant as well 


> Related Issues: 
> - https://github.com/wso2/apk/issues/3180
