### PR TITLE
Fix aws api deletion on delete api

### DIFF
--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayDeployer.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayDeployer.java
@@ -81,9 +81,17 @@ public class AWSGatewayDeployer implements GatewayDeployer {
     }
 
     @Override
-    public boolean undeploy(String externalReference) throws APIManagementException {
-        return AWSAPIUtil.deleteDeployment(externalReference, apiGatewayClient, stage);
+    public boolean undeploy(String externalReference, boolean delete) throws APIManagementException {
+        AWSAPIUtil.deleteDeployment(externalReference, apiGatewayClient, stage);
+        if (delete) {
+            AWSAPIUtil.deleteAPI(externalReference, apiGatewayClient);
+        }
+        return true;
+    }
 
+    @Override
+    public boolean undeploy(String externalReference) throws APIManagementException {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
fix aws api deletion on delete api
This pull request updates the AWS API Gateway deployment and undeployment logic to improve cleanup of resources and clarify method responsibilities. The most important changes include refactoring the undeploy process to optionally delete the API, updating the deployment deletion logic, and adding a utility method for deleting APIs.

**Deployment and Undeployment Improvements:**

* The `undeploy` method in `AWSGatewayDeployer.java` now accepts an additional `delete` flag, which triggers deletion of the API from AWS if set to true. This ensures both deployments and APIs can be cleaned up as needed.
* The `deleteDeployment` method in `AWSAPIUtil.java` has been refactored to remove its boolean return value and now ensures that stages are deleted before deleting deployments, improving resource cleanup. [[1]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eL511-R520) [[2]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eL532-R538)
* A new utility method `deleteAPI` has been added to `AWSAPIUtil.java` to delete a REST API from AWS API Gateway using its external reference. This is used by the updated undeploy logic.

**Code Quality and Minor Refactoring:**

* Minor formatting improvements were made to parameter mapping logic in `importRestAPI` and `reimportRestAPI` for better readability. [[1]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eL204-R207) [[2]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eL423-R427)
* Additional AWS SDK imports were added to support new functionality. [[1]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eR43) [[2]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eR58)