### PR TITLE
Bump azure orbit version and improvements

### DIFF
--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureConstants.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureConstants.java
@@ -49,6 +49,8 @@ public class AzureConstants {
 
     public static final String API_CONTEXT_VERSION_PLACEHOLDER = "{version}";
 
+    public static final String AZURE_NO_CONTEXT = "azure-no-context";
+
     public static final String AZURE_OAUTH2_OPERATION_POLICY_NAME = "azureOAuth2";
     public static final String AZURE_OAUTH2_OPERATION_POLICY_PARAMETER_OPENID_URL = "openIdURL";
 

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/util/AzureAPIUtil.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/util/AzureAPIUtil.java
@@ -391,7 +391,7 @@ public class AzureAPIUtil {
         API api = new API(apiIdentifier);
 
         String context = "/";
-        context += apiContract.path().isEmpty() ? api.getId().getApiName() : apiContract.path();
+        context += apiContract.path().isEmpty() ? AzureConstants.AZURE_NO_CONTEXT : apiContract.path();
         String contextTemplate = context + "/{version}";
         context += "/" + apiIdentifier.getVersion();
 

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -155,7 +155,7 @@
         <project.scm.id>scm-server</project.scm.id>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <carbon.apimgt.version>9.32.74</carbon.apimgt.version>
-        <org.wso2.orbit.azure.resourcemanager.apimanagement.version>2.0.0.wso2v2</org.wso2.orbit.azure.resourcemanager.apimanagement.version>
+        <org.wso2.orbit.azure.resourcemanager.apimanagement.version>2.0.0.wso2v3</org.wso2.orbit.azure.resourcemanager.apimanagement.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
     </properties>
 


### PR DESCRIPTION
Bump azure orbit version and make the context of azure APIs with no context into azure-no-context.

Will fix https://github.com/wso2/api-manager/issues/4133 properly.