### PR TITLE
Change azure.resourcemanager.apimanagement version

### DIFF
--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -155,7 +155,7 @@
         <project.scm.id>scm-server</project.scm.id>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <carbon.apimgt.version>9.32.74</carbon.apimgt.version>
-        <org.wso2.orbit.azure.resourcemanager.apimanagement.version>2.0.0.wso2v3</org.wso2.orbit.azure.resourcemanager.apimanagement.version>
+        <org.wso2.orbit.azure.resourcemanager.apimanagement.version>2.0.0.wso2v2</org.wso2.orbit.azure.resourcemanager.apimanagement.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
     </properties>
 


### PR DESCRIPTION
### Purpose

- Change org.wso2.orbit.azure.resourcemanager.apimanagement version to 2.0.0.wso2v2
- Related issues: https://github.com/wso2/api-manager/issues/4313